### PR TITLE
Set TEXT_CKEDITOR_BASE_PATH to fix static asset fetching with a CDN

### DIFF
--- a/prodekoorg/settings/prod.py
+++ b/prodekoorg/settings/prod.py
@@ -48,7 +48,10 @@ MEDIA_LOCATION = "media"
 STATIC_URL = f"https://{CDN_URL}/{STATIC_LOCATION}/"
 MEDIA_URL = f"https://{CDN_URL}/{MEDIA_LOCATION}/"
 
+# For django-ckeditor
 CKEDITOR_BASEPATH = f"https://{CDN_URL}/static/ckeditor/ckeditor/"
+# For djangocms-text-ckeditor
+TEXT_CKEDITOR_BASE_PATH = f"https://{CDN_URL}/static/djangocms_text_ckeditor/ckeditor/"
 
 # Django filer config
 FILER_STORAGES = {


### PR DESCRIPTION
Fixes this:
<img width="1409" alt="image" src="https://user-images.githubusercontent.com/25483483/95979551-76d1bb00-0e24-11eb-8288-b3d989bf8f90.png">
