### PR TITLE
Alumnirekisterin hakuparametribugi korjattu

### DIFF
--- a/alumnirekisteri/rekisteri/templates/ar_base.html
+++ b/alumnirekisteri/rekisteri/templates/ar_base.html
@@ -36,6 +36,9 @@
 					<div class="collapse navbar-collapse" id="navbar">
 						<form class="navbar-form navbar-left" method="get" action="{% url 'alumnirekisteri:search' %}">
 							<div class="form-group">
+								<input type="hidden" name="page" value="{% if page %}{{ page }}{% endif %}">
+							</div>
+							<div class="form-group">
 								<input type="text" name="search_first_name" value="{% if first_name %}{{ first_name }}{% endif %}" placeholder="Etunimi" class="form-control nav-haku">
 							</div>
 							<div class="form-group">

--- a/alumnirekisteri/rekisteri/templates/search.html
+++ b/alumnirekisteri/rekisteri/templates/search.html
@@ -43,13 +43,13 @@
        		<div class="pagination footer">
       			<span class="step-links">
            			{% if persons.has_previous %}
-           			<a href="?page={{ persons.previous_page_number }}">Edellinen</a>
+           			<a href="?page={{ persons.previous_page_number }}&search_first_name={% if first_name %}{{ first_name }}{% endif %}&search_last_name={% if last_name %}{{ last_name }}{% endif %}&search_start_year={% if class_of_year %}{{ class_of_year }}{% endif %}">Edellinen</a>
            			{% endif %}
            			<span class="current">
            				Sivu {{ persons.number }}/{{ persons.paginator.num_pages }}
            			</span>
            			{% if persons.has_next %}
-           			<a href="?page={{ persons.next_page_number }}">Seuraava</a>
+           			<a href="?page={{ persons.next_page_number }}&search_first_name={% if first_name %}{{ first_name }}{% endif %}&search_last_name={% if last_name %}{{ last_name }}{% endif %}&search_start_year={% if class_of_year %}{{ class_of_year }}{% endif %}">Seuraava</a>
            			{% endif %}
            		</span>
            		<div class="footer bottom-gradient" ></div>

--- a/alumnirekisteri/rekisteri/views.py
+++ b/alumnirekisteri/rekisteri/views.py
@@ -1840,6 +1840,7 @@ def search(request):
             "first_name": first_name,
             "last_name": last_name,
             "class_of_year": class_of_year,
+            "page": page,
         },
     )
 


### PR DESCRIPTION
tosiaan hieman purkkaratkaisu, mutta ainakin nyt toimii halutulla tavalla, eli hakuparametrit eivät nollaannu kun vaihtaa sivua
tl;dr hakuformiin laitettu piilotettu kenttä antamaan requesteissa parametrinä myös sivu, ja puolestaan templateen sivunvaihtoon hakuparametrit mukaan