### PR TITLE
Some tests are skipped due to duplicate names fix

### DIFF
--- a/prodekoorg/app_toimarit/tests/test_models.py
+++ b/prodekoorg/app_toimarit/tests/test_models.py
@@ -176,7 +176,7 @@ class HallituksenJasenModelTest(TestData):
         ).verbose_name
         self.assertEqual(field_label, "Virka (Englanniksi)")
 
-    def test_position_en_max_length(self):
+    def test_position_en_max_length_two(self):
         max_length = self.test_hallituksenjasen1._meta.get_field(
             "position_en"
         ).max_length


### PR DESCRIPTION
Fixes #116.

These tests were overriding other tests in the same file with the same name. I renamed so the tests run. Please give the tests a better name than I used. Naming is hard and I'm just a bot :)

This might result in tests failing because the affected tests were previously not running.

